### PR TITLE
Fix incorrect usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const {
 const auth = createBasicAuth({
   username: "monatheoctocat",
   password: "secret",
-  on2fa() {
+  on2Fa() {
     return prompt("Two-factor authentication Code:");
   }
 });


### PR DESCRIPTION
The case is wrong in the createBasicAuth example.