### PR TITLE
changed from pika.dev to skypack.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ GitHub supports 4 authentication strategies. They are all implemented in `@octok
 Browsers
 </th><td width=100%>
 
-Load `@octokit/auth` directly from [cdn.pika.dev](https://cdn.pika.dev)
+Load `@octokit/auth` directly from [cdn.skypack.dev](https://cdn.skypack.dev)
 
 ```html
 <script type="module">
@@ -40,7 +40,7 @@ Load `@octokit/auth` directly from [cdn.pika.dev](https://cdn.pika.dev)
     createAppAuth,
     createOAuthAppAuth,
     createTokenAuth,
-  } from "https://cdn.pika.dev/@octokit/auth";
+  } from "https://cdn.skypack.dev/@octokit/auth";
 </script>
 ```
 


### PR DESCRIPTION
Hi there!

made some changes accordingly to the README.md file, 
added the current CDN url, from cdn.pika.dev to cdn.skypack.dev and CDN Url has been changed.

review it, and let me know if any more changes are required..

thank you :)